### PR TITLE
chore: release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/kdheepak/pixel-peeker/compare/v0.3.5...v0.3.6) - 2025-09-29
+
+### Other
+
+- *(deps)* bump serde in the cargo-dependencies group ([#22](https://github.com/kdheepak/pixel-peeker/pull/22))
+
 ## [0.3.5](https://github.com/kdheepak/pixel-peeker/compare/v0.3.4...v0.3.5) - 2025-09-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "pixel-peeker"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "device_query",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixel-peeker"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 description = "A color eye dropper picker"
 license = "EUPL-1.2"


### PR DESCRIPTION



## 🤖 New release

* `pixel-peeker`: 0.3.5 -> 0.3.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.6](https://github.com/kdheepak/pixel-peeker/compare/v0.3.5...v0.3.6) - 2025-09-29

### Other

- *(deps)* bump serde in the cargo-dependencies group ([#22](https://github.com/kdheepak/pixel-peeker/pull/22))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).