### PR TITLE
chore: release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/kdheepak/pixel-peeker/compare/v0.3.6...v0.3.7) - 2026-05-26
+
+### Other
+
+- *(deps)* bump serde_json in the cargo-dependencies group ([#34](https://github.com/kdheepak/pixel-peeker/pull/34))
+- *(deps)* bump actions/github-script from 8 to 9 ([#33](https://github.com/kdheepak/pixel-peeker/pull/33))
+- *(deps)* bump xcap in the cargo-dependencies group ([#30](https://github.com/kdheepak/pixel-peeker/pull/30))
+- *(deps)* bump marocchino/sticky-pull-request-comment from 2 to 3 ([#31](https://github.com/kdheepak/pixel-peeker/pull/31))
+
 ## [0.3.6](https://github.com/kdheepak/pixel-peeker/compare/v0.3.5...v0.3.6) - 2025-12-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "pixel-peeker"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "device_query",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixel-peeker"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 description = "A color eye dropper picker"
 license = "EUPL-1.2"


### PR DESCRIPTION



## 🤖 New release

* `pixel-peeker`: 0.3.6 -> 0.3.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.7](https://github.com/kdheepak/pixel-peeker/compare/v0.3.6...v0.3.7) - 2026-05-26

### Other

- *(deps)* bump serde_json in the cargo-dependencies group ([#34](https://github.com/kdheepak/pixel-peeker/pull/34))
- *(deps)* bump actions/github-script from 8 to 9 ([#33](https://github.com/kdheepak/pixel-peeker/pull/33))
- *(deps)* bump xcap in the cargo-dependencies group ([#30](https://github.com/kdheepak/pixel-peeker/pull/30))
- *(deps)* bump marocchino/sticky-pull-request-comment from 2 to 3 ([#31](https://github.com/kdheepak/pixel-peeker/pull/31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).